### PR TITLE
Unix compatibility

### DIFF
--- a/mtga-export.py
+++ b/mtga-export.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Export your card collection from MTG: Arena
     Notes:
         Card Collection - PlayerInventory.GetPlayerCardsV3

--- a/mtga-export.py
+++ b/mtga-export.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Export your card collection from MTG: Arena
     Notes:
         Card Collection - PlayerInventory.GetPlayerCardsV3

--- a/mtga_log.py
+++ b/mtga_log.py
@@ -6,9 +6,8 @@ from mtga.set_data import all_mtga_cards
 import scryfall
 
 MTGA_COLLECTION_KEYWORD = "PlayerInventory.GetPlayerCardsV3"
-MTGA_WINDOWS_LOG_FILE = os.getenv('APPDATA')+"\\..\\LocalLow\\Wizards Of The Coast\\MTGA\\output_log.txt"
-MTGA_WINDOWS_FORMATS_FILE = os.getenv('APPDATA')+"\\..\\LocalLow\\Wizards Of The Coast\\MTGA\\formats.json"
-
+MTGA_WINDOWS_LOG_FILE = os.path.join(os.getenv('APPDATA'), "..", "LocalLow", "Wizards Of The Coast", "MTGA", "output_log.txt")
+MTGA_WINDOWS_FORMATS_FILE = os.path.join(os.getenv('APPDATA'), "..", "LocalLow", "Wizards Of The Coast", "MTGA", "formats.json")
 
 class MtgaLogParsingError(ValueError):
     """Exception raised when parsing json data fails"""

--- a/mtga_log.py
+++ b/mtga_log.py
@@ -10,7 +10,8 @@ def _mtga_file_path(filename):
     appdata = os.getenv("APPDATA")
     # If we don't have APPDATA, assume we're in the user's home directory
     base = [appdata, ".."] if appdata else ["AppData"]
-    return os.path.join(*base, "LocalLow", "Wizards Of The Coast", "MTGA", filename)
+    components = base + ["LocalLow", "Wizards of the Coast", "MTGA", filename]
+    return os.path.join(*components)
 
 MTGA_COLLECTION_KEYWORD = "PlayerInventory.GetPlayerCardsV3"
 MTGA_WINDOWS_LOG_FILE = _mtga_file_path("output_log.txt")

--- a/mtga_log.py
+++ b/mtga_log.py
@@ -5,9 +5,16 @@ import simplejson as json
 from mtga.set_data import all_mtga_cards
 import scryfall
 
+def _mtga_file_path(filename):
+    """Get the full path to the specified MTGA file"""
+    appdata = os.getenv("APPDATA")
+    # If we don't have APPDATA, assume we're in the user's home directory
+    base = [appdata, ".."] if appdata else ["AppData"]
+    return os.path.join(*base, "LocalLow", "Wizards Of The Coast", "MTGA", filename)
+
 MTGA_COLLECTION_KEYWORD = "PlayerInventory.GetPlayerCardsV3"
-MTGA_WINDOWS_LOG_FILE = os.path.join(os.getenv('APPDATA'), "..", "LocalLow", "Wizards Of The Coast", "MTGA", "output_log.txt")
-MTGA_WINDOWS_FORMATS_FILE = os.path.join(os.getenv('APPDATA'), "..", "LocalLow", "Wizards Of The Coast", "MTGA", "formats.json")
+MTGA_WINDOWS_LOG_FILE = _mtga_file_path("output_log.txt")
+MTGA_WINDOWS_FORMATS_FILE = _mtga_file_path("formats.json")
 
 class MtgaLogParsingError(ValueError):
     """Exception raised when parsing json data fails"""


### PR DESCRIPTION
While I'm well aware MTGA is a Windows-only program, I still prefer to do my development work in a Unix-like environment, either Windows Subsystem for Linux or full-on dual-booted Linux. This PR is three small changes which makes that less painful:

1. Set the executable bit on the top-level script and put the magic `#!` line at the top so Unix shells know it's a Python script.
2. If `APPDATA` does exist and point at the right place, use `os.path.join` to build the path to the log file rather than explicit backslashes (which don't work on Unix)
3. Don't blow up if `APPDATA` doesn't exist. The default value (assuming that the script is being run from the user's Windows home directory) probably isn't going to be very useful, but at least it now gets as far as showing an error message.