### PR TITLE
Add convenience function to get player's inventory, including vault progress

### DIFF
--- a/mtga_log.py
+++ b/mtga_log.py
@@ -14,6 +14,7 @@ def _mtga_file_path(filename):
     return os.path.join(*components)
 
 MTGA_COLLECTION_KEYWORD = "PlayerInventory.GetPlayerCardsV3"
+MTGA_INVENTORY_KEYWORD = "PlayerInventory.GetPlayerInventory"
 MTGA_WINDOWS_LOG_FILE = _mtga_file_path("output_log.txt")
 MTGA_WINDOWS_FORMATS_FILE = _mtga_file_path("formats.json")
 
@@ -99,6 +100,10 @@ class MtgaLog(object):
             if card is not None:
                 yield [mtga_id, card, count]
 
+    def get_inventory(self):
+        """Convenience function to get the player's inventory"""
+        inventory_dict = self.get_last_json_block('<== ' + MTGA_INVENTORY_KEYWORD)
+        return MtgaInventory(inventory_dict)
 
 
 class MtgaFormats(object):
@@ -134,3 +139,37 @@ class MtgaFormats(object):
     def get_set_card_count(self, mtga_set):
         set_info = self.get_set_info(mtga_set)
         return set_info.get('card_count', 0)
+
+class MtgaInventory(object):
+    """Wrapper for the player's inventory"""
+
+    def __init__(self, inventory_dict):
+        self.inventory_dict = inventory_dict
+
+    @property
+    def gems(self):
+        return self.inventory_dict['gems']
+
+    @property
+    def gold(self):
+        return self.inventory_dict['gold']
+
+    @property
+    def tokens(self):
+        return {
+            'Draft': self.inventory_dict['draftTokens'],
+            'Sealed': self.inventory_dict['sealedTokens']
+        }
+
+    @property
+    def vault_progress(self):
+        return self.inventory_dict['vaultProgress']
+
+    @property
+    def wildcards(self):
+        return {
+            'Common': self.inventory_dict['wcCommon'],
+            'Uncommon': self.inventory_dict['wcUncommon'],
+            'Rare': self.inventory_dict['wcRare'],
+            'Mythic Rare': self.inventory_dict['wcMythic']
+        }

--- a/tests/test_mtga_export.py
+++ b/tests/test_mtga_export.py
@@ -73,7 +73,18 @@ class Test_MtgaLog(unittest.TestCase):
                     mtga_id, card, count = next(collection)
                     self.assertIsInstance(card, scryfall.ScryfallError)
 
+    def test_inventory(self):
+        inventory = self.mlog.get_inventory()
 
+        self.assertEqual(inventory.gems, 1)
+        self.assertEqual(inventory.gold, 2)
+        self.assertEqual(inventory.tokens['Draft'], 3)
+        self.assertEqual(inventory.tokens['Sealed'], 4)
+        self.assertEqual(inventory.vault_progress, 5.6)
+        self.assertEqual(inventory.wildcards['Common'], 7)
+        self.assertEqual(inventory.wildcards['Uncommon'], 8)
+        self.assertEqual(inventory.wildcards['Rare'], 9)
+        self.assertEqual(inventory.wildcards['Mythic Rare'], 10)
 
 class Test_Scryfall(unittest.TestCase):
     """Test the scryfall module"""

--- a/tests/test_mtga_output_log.txt
+++ b/tests/test_mtga_output_log.txt
@@ -17,6 +17,19 @@
     "70192": "1"
 }
 
+<== PlayerInventory.GetPlayerInventory(579)
+{
+  "wcCommon": 7,
+  "wcUncommon": 8,
+  "wcRare": 9,
+  "wcMythic": 10,
+  "gold": 2,
+  "gems": 1,
+  "draftTokens": 3,
+  "sealedTokens": 4,
+  "vaultProgress": 5.6
+}
+
 <== TestKey
 {
     "test1":


### PR DESCRIPTION
Nothing big or clever here.

As you're probably aware, the MTGA vault progress isn't visible in the UI until you hit 100% but is in the log file.

This just adds a convenience function which fetches the appropriate JSON blob from the log file and parses out the obvious properties.