### PR TITLE
Get deck lists

### DIFF
--- a/mtga_log.py
+++ b/mtga_log.py
@@ -136,6 +136,7 @@ class MtgaLog(object):
     def get_deck_lists(self):
         """Get all deck lists"""
         deck_lists_json = self.get_last_json_block('<== ' + MTGA_DECK_LISTS_KEYWORD)
+        deck_lists_json = deck_lists_json.get('payload', deck_lists_json)
         return [MtgaDeckList(j, self) for j in deck_lists_json]
 
 class MtgaInventory(object):

--- a/mtga_log.py
+++ b/mtga_log.py
@@ -205,6 +205,10 @@ class MtgaDeckList(object):
         self.deckbox_image = card_lookup.lookup_card(self.deck_list_json['deckTileId'])
 
     @property
+    def deck_id(self):
+        return self.deck_list_json['id']
+
+    @property
     def name(self):
         return self.deck_list_json['name']
 

--- a/mtga_log.py
+++ b/mtga_log.py
@@ -100,6 +100,12 @@ class MtgaLog(object):
             if card is not None:
                 yield [mtga_id, card, count]
 
+    def lookup_card(self, mtga_id):
+        try:
+            return all_mtga_cards.find_one(mtga_id)
+        except ValueError as exception:
+            return self._fetch_card_from_scryfall(mtga_id)
+
     def get_collection(self):
         """Generator for MTGA collection"""
         collection = self.get_last_json_block('<== ' + MTGA_COLLECTION_KEYWORD)
@@ -194,6 +200,8 @@ class MtgaDeckList(object):
 
         sideboard_pairs = zip(*[iter(self.deck_list_json['sideboard'])]*2)
         self.sideboard = card_lookup.lookup_cards(sideboard_pairs)
+
+        self.deckbox_image = card_lookup.lookup_card(self.deck_list_json['deckTileId'])
 
     @property
     def name(self):

--- a/mtga_log.py
+++ b/mtga_log.py
@@ -57,10 +57,10 @@ class MtgaLog(object):
                     bucket = []
                     copy = True
 
-                levels += line.count('{')
-                levels -= line.count('}')
+                levels += line.count('{') + line.count('[')
+                levels -= line.count('}') + line.count(']')
 
-                if line.count('}') > 0 and levels == 0:
+                if (line.count('}') > 0 or line.count(']') > 0) and levels == 0:
                     copy = False
         return bucket
 

--- a/tests/test_mtga_export.py
+++ b/tests/test_mtga_export.py
@@ -128,6 +128,7 @@ class Test_MtgaLog(unittest.TestCase):
         self.assertEqual(count, 1)
 
         self.assertEqual(kethis_deck.deckbox_image.pretty_name, 'Fblthp, the Lost')
+        self.assertEqual(kethis_deck.deck_id, '72ea9e67-1091-4e1c-81c2-3f2327378984')
 
 class Test_Scryfall(unittest.TestCase):
     """Test the scryfall module"""

--- a/tests/test_mtga_export.py
+++ b/tests/test_mtga_export.py
@@ -27,6 +27,12 @@ class Test_MtgaLog(unittest.TestCase):
             , '1'
         )
 
+    def test_get_last_json_block_with_array(self):
+        result = self.mlog.get_last_json_block('<== TestArray')
+        self.assertEqual(
+            result[0].get('key'), 'value'
+        )
+
     def test_get_last_json_block2(self):
         result = self.mlog.get_last_json_block('blah')
         self.assertEqual(result.get('foo'), 'bar')

--- a/tests/test_mtga_export.py
+++ b/tests/test_mtga_export.py
@@ -92,6 +92,24 @@ class Test_MtgaLog(unittest.TestCase):
         self.assertEqual(inventory.wildcards['Rare'], 9)
         self.assertEqual(inventory.wildcards['Mythic Rare'], 10)
 
+    def test_deck_lists(self):
+        deck_lists = self.mlog.get_deck_lists()
+
+        self.assertEqual(len(deck_lists), 2)
+        kethis_deck = deck_lists[0]
+        self.assertEqual(kethis_deck.name, 'Kethis Combo')
+        self.assertEqual(kethis_deck.format, 'Standard')
+
+        mtga_id, card, count = list(kethis_deck.maindeck)[0]
+        self.assertEqual(mtga_id, 69996)
+        self.assertEqual(card.pretty_name, 'Kethis, the Hidden Hand')
+        self.assertEqual(count, 4)
+
+        mtga_id, card, count = list(kethis_deck.sideboard)[1]
+        self.assertEqual(mtga_id, 68645)
+        self.assertEqual(card.pretty_name, 'Lazav, the Multifarious')
+        self.assertEqual(count, 1)
+
 class Test_Scryfall(unittest.TestCase):
     """Test the scryfall module"""
 

--- a/tests/test_mtga_export.py
+++ b/tests/test_mtga_export.py
@@ -110,6 +110,8 @@ class Test_MtgaLog(unittest.TestCase):
         self.assertEqual(card.pretty_name, 'Lazav, the Multifarious')
         self.assertEqual(count, 1)
 
+        self.assertEqual(kethis_deck.deckbox_image.pretty_name, 'Fblthp, the Lost')
+
 class Test_Scryfall(unittest.TestCase):
     """Test the scryfall module"""
 

--- a/tests/test_mtga_output_log.txt
+++ b/tests/test_mtga_output_log.txt
@@ -19,7 +19,7 @@
 
 <== PlayerInventory.GetPlayerInventory {"id":579,"payload":{"wcCommon":7,"wcUncommon":8,"wcRare":9,"wcMythic":10,"gold":2,"gems":1,"draftTokens":3,"sealedTokens":4,"vaultProgress":5.6}}
 
-<== Deck.GetDeckListsV3 {"id":1,"payload":[{"name":"Kethis Combo","format":"Standard","deckTileId":69501,"mainDeck":[69996,4,67552,3],"sideboard":[67206,2,68645,1]},{"name":"Empty Deck","format":"Standard","deckTileId":66499,"mainDeck":[],"sideboard":[]}]}
+<== Deck.GetDeckListsV3 {"id":1,"payload":[{"id":"72ea9e67-1091-4e1c-81c2-3f2327378984","name":"Kethis Combo","format":"Standard","deckTileId":69501,"mainDeck":[69996,4,67552,3],"sideboard":[67206,2,68645,1]},{"id":"9a30e51b-430e-4879-bfbc-d801e3447b23","name":"Empty Deck","format":"Standard","deckTileId":66499,"mainDeck":[],"sideboard":[]}]}
 
 <== KeywordOne {"id":1,"payload":{ "value": 1}}
 

--- a/tests/test_mtga_output_log.txt
+++ b/tests/test_mtga_output_log.txt
@@ -35,6 +35,7 @@
   {
     "name": "Kethis Combo",
     "format": "Standard",
+    "deckTileId": 69501,
     "mainDeck": [
       69996,
       4,
@@ -51,6 +52,7 @@
   {
     "name": "Empty Deck",
     "format": "Standard",
+    "deckTileId": 66499,
     "mainDeck": [
     ],
     "sideboard": [

--- a/tests/test_mtga_output_log.txt
+++ b/tests/test_mtga_output_log.txt
@@ -17,48 +17,9 @@
     "70192": "1"
 }
 
-<== PlayerInventory.GetPlayerInventory(579)
-{
-  "wcCommon": 7,
-  "wcUncommon": 8,
-  "wcRare": 9,
-  "wcMythic": 10,
-  "gold": 2,
-  "gems": 1,
-  "draftTokens": 3,
-  "sealedTokens": 4,
-  "vaultProgress": 5.6
-}
+<== PlayerInventory.GetPlayerInventory {"id":579,"payload":{"wcCommon":7,"wcUncommon":8,"wcRare":9,"wcMythic":10,"gold":2,"gems":1,"draftTokens":3,"sealedTokens":4,"vaultProgress":5.6}}
 
-<== Deck.GetDeckListsV3(1)
-[
-  {
-    "name": "Kethis Combo",
-    "format": "Standard",
-    "deckTileId": 69501,
-    "mainDeck": [
-      69996,
-      4,
-      67552,
-      3
-    ],
-    "sideboard": [
-      67206,
-      2,
-      68645,
-      1
-    ]
-  },
-  {
-    "name": "Empty Deck",
-    "format": "Standard",
-    "deckTileId": 66499,
-    "mainDeck": [
-    ],
-    "sideboard": [
-    ]
-  }
-]
+<== Deck.GetDeckListsV3 {"id":1,"payload":[{"name":"Kethis Combo","format":"Standard","deckTileId":69501,"mainDeck":[69996,4,67552,3],"sideboard":[67206,2,68645,1]},{"name":"Empty Deck","format":"Standard","deckTileId":66499,"mainDeck":[],"sideboard":[]}]}
 
 <== KeywordOne {"id":1,"payload":{ "value": 1}}
 

--- a/tests/test_mtga_output_log.txt
+++ b/tests/test_mtga_output_log.txt
@@ -30,6 +30,34 @@
   "vaultProgress": 5.6
 }
 
+<== Deck.GetDeckListsV3(1)
+[
+  {
+    "name": "Kethis Combo",
+    "format": "Standard",
+    "mainDeck": [
+      69996,
+      4,
+      67552,
+      3
+    ],
+    "sideboard": [
+      67206,
+      2,
+      68645,
+      1
+    ]
+  },
+  {
+    "name": "Empty Deck",
+    "format": "Standard",
+    "mainDeck": [
+    ],
+    "sideboard": [
+    ]
+  }
+]
+
 <== TestKey
 {
     "test1":

--- a/tests/test_mtga_output_log.txt
+++ b/tests/test_mtga_output_log.txt
@@ -41,6 +41,13 @@
         }
     }}
 
+<== TestArray
+[
+  {
+    "key": "value"
+  }
+]
+
 blah
 { "foo" : "bar" }
 


### PR DESCRIPTION
While you can export your decks one at a time from Arena, that's tedious. Add parsing of all decks at once from the logfile.

This turned out to be only very slightly less trivial than it might have been:

* The JSON parser could parse only top-level JSON objects, not top-level JSON arrays. Functionality added - although it will break if somebody calls their deck `Silly Name ]` (haven't actually tried to see if that's possible in the client).
* I'm not 100% happy with how the "lookup cards" functionality means injecting `MtgaLog` into `MtgaDeckList` for just the card lookup functionality - in an ideal world, that functionality should probably live in a separate object. I think this is OK for now but happy to refactor a bit if you'd prefer.