### PR TITLE
Fix case sensitive path for linux

### DIFF
--- a/mtga_log.py
+++ b/mtga_log.py
@@ -11,7 +11,7 @@ def _mtga_file_path(filename):
     appdata = os.getenv("APPDATA")
     # If we don't have APPDATA, assume we're in the user's home directory
     base = [appdata, ".."] if appdata else ["AppData"]
-    components = base + ["LocalLow", "Wizards of the Coast", "MTGA", filename]
+    components = base + ["LocalLow", "Wizards Of The Coast", "MTGA", filename]
     return os.path.join(*components)
 
 MTGA_COLLECTION_KEYWORD = "PlayerInventory.GetPlayerCardsV3"


### PR DESCRIPTION
This can work on linux by exporting a couple environment variables:

export ProgramFiles="/home/$USER/Games/magic-the-gathering-arena/drive_c/Program Files (x86)"
export APPDATA="/home/$USER/Games/magic-the-gathering-arena/drive_c/users/$USER/AppData/LocalLow"

But since linux is case sensitive while Windows is not, I needed to fix this first.