### PR TITLE
changes to allow mtga_log.py to be imported as a module

### DIFF
--- a/mtga_log.py
+++ b/mtga_log.py
@@ -2,8 +2,10 @@ from __future__ import print_function
 from future.utils import iteritems
 import os
 import simplejson as json
-import scryfall
 import re
+import importlib
+
+scryfall = importlib.import_module(__name__, 'scryfall')
 
 
 def _mtga_file_path(filename):


### PR DESCRIPTION
mtga_log.py is very useful for my MTG Arena projects, but when you try to import it as a module (`from mtga_utils import mtga_log` with `mtga_utils` in a subfolder) it throws an error:

```
Traceback (most recent call last):
  File "c:/Users/billy/code/mtga_decklist_viewer/mtga_decklist_viewer.pyw", line 11, in <module>
    from mtga_utils import mtga_log
  File "c:\Users\billy\code\mtga_decklist_viewer\mtga_utils\mtga_log.py", line 6, in <module>
    import scryfall
ModuleNotFoundError: No module named 'scryfall'
```

This is due to how Python handles relative imports—it's looking for the `scryfall` module in the base folder instead of the mtga_utils folder.

This solution should work fine. Unfortunately, the repo name `mtga-utils` is not a valid package name, so I couldn't simply change the import code to `from mtga-utils import scryfall`.