### PR TITLE
Handle log file lines with unmatched delimiters.

### DIFF
--- a/mtga_log.py
+++ b/mtga_log.py
@@ -87,8 +87,9 @@ class MtgaLog(object):
                 if copy and line:
                     bucket.append(line)
 
-                dict_levels += line.count('{') - line.count('}')
-                list_levels += line.count('[') - line.count(']')
+                if copy:
+                    dict_levels += line.count('{') - line.count('}')
+                    list_levels += line.count('[') - line.count(']')
 
                 if line.count('}') > 0 and dict_levels == 0 and list_levels == 0:
                     copy = False

--- a/tests/test_mtga_output_log.txt
+++ b/tests/test_mtga_output_log.txt
@@ -1,3 +1,5 @@
+RingDoorbell [fdHost:client.arenagame-a.east.magic-the-gathering-arena.com, fdPort:9405, contentHash:
+
 <== PlayerInventory.GetPlayerCardsV3(10)
 {
     "67682": "1",


### PR DESCRIPTION
My most recent MTGA logfiles have contained the `RingDoorbell` line added to the test data; this breaks the parsing due to the unmatched `[`. Fix this by only counting delimiters when we're adding lines to the bucket.

(The Scryfall test is still failing after this change but I'm sure that's unrelated)